### PR TITLE
MIMIC Multiple Positive Query Accuracy

### DIFF
--- a/data_analysis/mimic_multiple_pos_cossim_accuracy_analysis.ipynb
+++ b/data_analysis/mimic_multiple_pos_cossim_accuracy_analysis.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cosine_path = \"/home/imadejski/ctds-search-model/data/multiple_pos_cosine_similarity_new2.csv\"\n",
+    "cosine_df = pd.read_csv(cosine_path)\n",
+    "\n",
+    "labels_path = \"/opt/gpudata/mimic-cxr/mimic-cxr-2.0.0-chexpert.csv.gz\"\n",
+    "labels_df = pd.read_csv(labels_path)\n",
+    "\n",
+    "split_path = \"/opt/gpudata/mimic-cxr/mimic-cxr-2.0.0-split.csv.gz\"\n",
+    "split_df = pd.read_csv(split_path)\n",
+    "\n",
+    "valid_df = split_df[split_df['split'] == 'validate']\n",
+    "valid_study_ids = valid_df['study_id'].unique()\n",
+    "valid_labels_df = labels_df[labels_df['study_id'].isin(valid_study_ids)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = [\n",
+    "        \"Atelectasis\",\n",
+    "        \"Cardiomegaly\",\n",
+    "        \"Consolidation\",\n",
+    "        \"Edema\",\n",
+    "        \"Enlarged Cardiomediastinum\",\n",
+    "        \"Fracture\",\n",
+    "        \"Lung Lesion\",\n",
+    "        \"Lung Opacity\",\n",
+    "        \"No Finding\",\n",
+    "        \"Pleural Effusion\",\n",
+    "        \"Pleural Other\",\n",
+    "        \"Pneumonia\",\n",
+    "        \"Pneumothorax\",\n",
+    "        \"Support Devices\"\n",
+    "    ]\n",
+    "    \n",
+    "embedding_types = [\n",
+    "        'cosine_similarity_1',\n",
+    "        'cosine_similarity_2',\n",
+    "        'cosine_similarity_3',\n",
+    "        'cosine_similarity_4',\n",
+    "        'average_embedding',\n",
+    "        'average_cosine_similarity',\n",
+    "        'max_cosine_similarity'\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []\n",
+    "for label in labels:\n",
+    "    for emb in embedding_types:\n",
+    "        column_name = f'{label} {emb}'\n",
+    "        if column_name in cosine_df.columns:\n",
+    "            temp_df = cosine_df[['subject_id', 'study_id', 'dicom_id', column_name]].copy()\n",
+    "            temp_df.rename(columns={column_name: 'cosine_similarity'}, inplace=True)\n",
+    "            temp_df['label'] = label\n",
+    "            temp_df['embedding_type'] = emb\n",
+    "            temp_df['cosine_similarity'] = pd.to_numeric(temp_df['cosine_similarity'], errors='coerce')\n",
+    "            data.append(temp_df)\n",
+    "        else:\n",
+    "            print(f\"Warning: Column {column_name} does not exist in cosine_df\")\n",
+    "\n",
+    "if data:\n",
+    "    cosine_df_transformed = pd.concat(data, ignore_index=True)\n",
+    "else:\n",
+    "    print(\"No data to concatenate. Please check the input DataFrame and configurations.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_counts = {}\n",
+    "\n",
+    "for label in labels:\n",
+    "    label_positives = valid_labels_df[valid_labels_df[label] == 1]\n",
+    "    unique_positive_study_ids = label_positives['study_id'].unique()\n",
+    "    n_counts[label] = len(unique_positive_study_ids)\n",
+    "\n",
+    "print(n_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def aggregate_cosine(df, method):\n",
+    "    if method == 'max':\n",
+    "        return df.groupby(['study_id', 'label', 'embedding_type'])['cosine_similarity'].max().reset_index()\n",
+    "    elif method == 'mean':\n",
+    "        return df.groupby(['study_id', 'label', 'embedding_type'])['cosine_similarity'].mean().reset_index()\n",
+    "\n",
+    "cosine_max = aggregate_cosine(cosine_df_transformed, 'max')\n",
+    "cosine_mean = aggregate_cosine(cosine_df_transformed, 'mean')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = {}\n",
+    "for label in labels:\n",
+    "    n = n_counts[label]  # Retrieve the count of positives for the current label\n",
+    "    for emb in embedding_types:\n",
+    "        max_df = cosine_max[(cosine_max['label'] == label) & (cosine_max['embedding_type'] == emb)]\n",
+    "        mean_df = cosine_mean[(cosine_mean['label'] == label) & (cosine_mean['embedding_type'] == emb)]\n",
+    "\n",
+    "        top_n_max = max_df.nlargest(n, 'cosine_similarity')['study_id']\n",
+    "        top_n_mean = mean_df.nlargest(n, 'cosine_similarity')['study_id']\n",
+    "\n",
+    "        label_positives = labels_df[labels_df[label] == 1]['study_id']\n",
+    "        \n",
+    "        results[f'{label} {emb}_max'] = top_n_max.isin(label_positives).sum() / n\n",
+    "        results[f'{label} {emb}_mean'] = top_n_mean.isin(label_positives).sum() / n\n",
+    "\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = {}\n",
+    "\n",
+    "# Loop over each label\n",
+    "for label in labels:\n",
+    "    n = n_counts[label]  # Retrieve the count of positives for the current label\n",
+    "    # Initialize sub-dictionary for storing accuracy scores for the current label\n",
+    "    label_results = {}\n",
+    "    \n",
+    "    # Filter only the required embedding types\n",
+    "    filtered_embedding_types = ['average_embedding', 'average_cosine_similarity', 'max_cosine_similarity']\n",
+    "    \n",
+    "    for emb in filtered_embedding_types:\n",
+    "        # Assume cosine_max and cosine_mean DataFrames are already defined and have the required structure\n",
+    "        max_df = cosine_max[(cosine_max['label'] == label) & (cosine_max['embedding_type'] == emb)]\n",
+    "        mean_df = cosine_mean[(cosine_mean['label'] == label) & (cosine_mean['embedding_type'] == emb)]\n",
+    "\n",
+    "        # Calculate max and mean accuracies\n",
+    "        top_n_max = max_df.nlargest(n, 'cosine_similarity')['study_id']\n",
+    "        top_n_mean = mean_df.nlargest(n, 'cosine_similarity')['study_id']\n",
+    "\n",
+    "        label_positives = valid_labels_df[valid_labels_df[label] == 1]['study_id']\n",
+    "        \n",
+    "        # Store the calculated accuracies in the label_results\n",
+    "        label_results[f'{emb}_max_accuracy'] = top_n_max.isin(label_positives).sum() / n\n",
+    "        label_results[f'{emb}_mean_accuracy'] = top_n_mean.isin(label_positives).sum() / n\n",
+    "\n",
+    "    # Add the label_results to the main results dictionary with the label as the key\n",
+    "    results[label] = label_results\n",
+    "\n",
+    "# Convert the dictionary to a DataFrame where each row corresponds to a label and each column to an accuracy score\n",
+    "results_df = pd.DataFrame.from_dict(results, orient='index')\n",
+    "\n",
+    "# Save the DataFrame to a CSV file\n",
+    "results_df.to_csv('/home/imadejski/ctds-search-model/data_analysis/accuracy_results.csv', index=True, index_label='Label')\n",
+    "\n",
+    "# Optionally print the DataFrame\n",
+    "print(results_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(valid_labels_df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "himl",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mimic_multiple_pos_labels.py
+++ b/mimic_multiple_pos_labels.py
@@ -1,0 +1,192 @@
+from math import ceil, floor
+from pathlib import Path
+from typing import Callable, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+import requests
+import torch
+import torch.nn.functional as F
+from health_multimodal.image import ImageInferenceEngine
+from health_multimodal.image.data.transforms import (
+    create_chest_xray_transform_for_inference,
+)
+from health_multimodal.image.model.pretrained import get_biovil_t_image_encoder
+from health_multimodal.text import TextInferenceEngine
+from health_multimodal.text.utils import BertEncoderType, get_bert_inference
+from health_multimodal.vlp.inference_engine import ImageTextInferenceEngine
+from scipy import ndimage
+from torchvision.datasets.utils import check_integrity
+from transformers import BertForMaskedLM, BertTokenizer
+
+RESIZE = 512
+CENTER_CROP_SIZE = 512
+
+
+def _get_vlp_inference_engine() -> ImageTextInferenceEngine:
+    """
+    Creates an returns an instance of the ImageTextInferenceEngine
+    """
+    image_inference = ImageInferenceEngine(
+        image_model=get_biovil_t_image_encoder(),
+        transform=create_chest_xray_transform_for_inference(
+            resize=RESIZE, center_crop_size=CENTER_CROP_SIZE
+        ),
+    )
+    img_txt_inference = ImageTextInferenceEngine(
+        image_inference_engine=image_inference,
+        text_inference_engine=get_bert_inference(BertEncoderType.BIOVIL_T_BERT),
+    )
+    return img_txt_inference
+
+
+def np_array_to_torch_tensor(np_array):
+    """
+    Takes a nump array and converts it to a torch tensor with datatype float32
+    """
+    torch_tensor = torch.tensor(np_array, dtype=torch.float32)
+    return torch_tensor
+
+
+def img_embeddings_df(path):
+    """
+    Takes a path for a file path for a csv that holds information about image imbeddings
+    Returns a Pandas dataframe
+    """
+    embeddings_pd = pd.read_csv(path)
+    return embeddings_pd
+
+
+def create_pos_search_queries_for_label(label):
+    """
+    Takes a label (string) and creates a list of positive search queries for a given
+    """
+    pos_search_queries = [
+        f"Findings consistent with {label}",
+        f"Findings suggesting {label}",
+        f"Findings are most compatible with {label}",
+        f"{label} seen",
+    ]
+    return pos_search_queries
+
+
+def average_embedding(search_queries, inference_engine):
+    """
+    Takes a list of search queries and returns the average embedding
+    """
+    avg_embedding = inference_engine.get_embeddings_from_prompt(search_queries)
+
+    return avg_embedding
+
+
+def create_search_queries_embedding(search_queries, inference_engine):
+    """
+    Takes a list of search queries and returns list of embeddings for each search query
+    """
+    search_queries_embeddings = []
+    for query in search_queries:
+        embedding = inference_engine.get_embeddings_from_prompt(query)
+        search_queries_embeddings.append(embedding)
+    return search_queries_embeddings
+
+
+def find_cosine_similarity(img_embedding, search_query_embedding):
+    """
+    Takes an image embedding and search query embedding as torch tensors and returns the cosine
+    similarity score
+    Img embedding size should be ([128]) and text embedding is ([1, 128])
+    """
+    img_embedding_reshaped = img_embedding.reshape(1, 128)
+
+    text_embedding = search_query_embedding.mean(dim=0)
+    text_embedding = F.normalize(text_embedding, dim=0, p=2)
+
+    cos_similarity = img_embedding @ text_embedding.t()
+    return cos_similarity.item()
+
+
+def convert_string_to_np(embedding_str):
+    """
+    Converts a string to a numpy array
+    """
+    return np.fromstring(embedding_str[1:-1], sep=" ")
+
+
+def main():
+    text_inference = get_bert_inference(BertEncoderType.BIOVIL_T_BERT)
+
+    labels = [
+        "Atelectasis",
+        "Cardiomegaly",
+        "Consolidation",
+        "Edema",
+        "Enlarged Cardiomediastinum",
+        "Fracture",
+        "Lung Lesion",
+        "Lung Opacity",
+        "No Finding",
+        "Pleural Effusion",
+        "Pleural Other",
+        "Pneumonia",
+        "Pneumothorax",
+        "Support Devices",
+    ]
+
+    mimic_embedding_library_path = (
+        "/home/imadejski/ctds-search-model/data/mimic_validate_embedding_library.csv"
+    )
+    mimic_embeddings_pd = img_embeddings_df(mimic_embedding_library_path)
+
+    for label in labels:
+        pos_search_queries = create_pos_search_queries_for_label(label)
+        pos_embeddings = create_search_queries_embedding(
+            pos_search_queries, text_inference
+        )
+        avg_pos_embedding = average_embedding(pos_search_queries, text_inference)
+
+        for i in range(len(pos_search_queries)):
+            mimic_embeddings_pd[f"{label} cosine_similarity_{i+1}"] = np.nan
+
+        mimic_embeddings_pd[f"{label} average_embedding"] = np.nan
+        mimic_embeddings_pd[f"{label} average_cosine_similarity"] = np.nan
+        mimic_embeddings_pd[f"{label} max_cosine_similarity"] = np.nan
+
+        for index, row in mimic_embeddings_pd.iterrows():
+            img_embedding_string = row["embedding"]
+            img_embedding_np = convert_string_to_np(img_embedding_string)
+            img_embedding = np_array_to_torch_tensor(img_embedding_np)
+
+            cosine_similarities = []
+            for i, pos_embedding in enumerate(pos_embeddings):
+                cosine_similarity = find_cosine_similarity(img_embedding, pos_embedding)
+                mimic_embeddings_pd.at[
+                    index, f"{label} cosine_similarity_{i+1}"
+                ] = cosine_similarity
+                cosine_similarities.append(cosine_similarity)
+
+            average_embedding_cosine_similarity = find_cosine_similarity(
+                img_embedding, avg_pos_embedding
+            )
+            mimic_embeddings_pd.at[
+                index, f"{label} average_embedding"
+            ] = average_embedding_cosine_similarity
+
+            if cosine_similarities:
+                average_of_cosine_similarities = np.mean(cosine_similarities)
+                mimic_embeddings_pd.at[
+                    index, f"{label} average_cosine_similarity"
+                ] = average_of_cosine_similarities
+
+                max_of_cosine_similarities = np.max(cosine_similarities)
+                mimic_embeddings_pd.at[
+                    index, f"{label} max_cosine_similarity"
+                ] = max_of_cosine_similarities
+
+    output_file_path = (
+        "/home/imadejski/ctds-search-model/data/multiple_pos_cosine_similarity_new2.csv"
+    )
+    mimic_embeddings_pd.to_csv(output_file_path, index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description of proposed changes

Adds the python notebook that calculates the accuracy values of the MIMIC cosine similarity scoring with top n. This takes the top n highest cosine similarity values (multiple ways) and compares it to the positive matches in the chexpert labels.

## Related issue(s)

Fixes #

Related to #

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?
